### PR TITLE
Add game logic service and tests

### DIFF
--- a/src/app/game.service.spec.ts
+++ b/src/app/game.service.spec.ts
@@ -1,0 +1,33 @@
+import { applyMove, GameState, Car, isMoveLegal, isCleared } from './game.service';
+
+describe('GameService logic', () => {
+  function createState(): GameState {
+    const cars: Car[] = [
+      { id: 'red', isMain: true, orientation: 'horizontal', length: 2, x: 1, y: 2 },
+      { id: 'blocker', isMain: false, orientation: 'vertical', length: 3, x: 4, y: 0 }
+    ];
+    return { boardSize: 6, cars, moveCount: 0, isCleared: false, history: [] };
+  }
+
+  it('rejects moves that collide with another car', () => {
+    const state = createState();
+    const move = { carId: 'red', direction: 'right', steps: 3 } as const;
+    expect(isMoveLegal(state, move)).toBeFalse();
+  });
+
+  it('rejects moves that go out of bounds', () => {
+    const state = createState();
+    const move = { carId: 'blocker', direction: 'up', steps: 1 } as const;
+    expect(isMoveLegal(state, move)).toBeFalse();
+  });
+
+  it('detects victory when red car reaches the exit', () => {
+    const state = createState();
+    // remove blocking car so path is clear
+    state.cars = state.cars.filter(c => c.id !== 'blocker');
+    const move = { carId: 'red', direction: 'right', steps: 3 } as const;
+    const newState = applyMove(state, move);
+    expect(newState.isCleared).toBeTrue();
+    expect(isCleared(newState)).toBeTrue();
+  });
+});

--- a/src/app/game.service.ts
+++ b/src/app/game.service.ts
@@ -1,0 +1,150 @@
+export interface Car {
+  id: string;
+  isMain: boolean;
+  orientation: 'horizontal' | 'vertical';
+  length: 2 | 3;
+  x: number;
+  y: number;
+}
+
+export interface Move {
+  carId: string;
+  direction: 'left' | 'right' | 'up' | 'down';
+  steps: number;
+}
+
+export interface GameState {
+  boardSize: number;
+  cars: Car[];
+  moveCount: number;
+  isCleared: boolean;
+  history: Move[];
+}
+
+export function getOccupiedGrid(state: GameState): (string | null)[][] {
+  const grid: (string | null)[][] = [];
+  for (let y = 0; y < state.boardSize; y++) {
+    grid[y] = [];
+    for (let x = 0; x < state.boardSize; x++) {
+      grid[y][x] = null;
+    }
+  }
+  for (const car of state.cars) {
+    for (let i = 0; i < car.length; i++) {
+      const x = car.orientation === 'horizontal' ? car.x + i : car.x;
+      const y = car.orientation === 'vertical' ? car.y + i : car.y;
+      grid[y][x] = car.id;
+    }
+  }
+  return grid;
+}
+
+export function isMoveLegal(state: GameState, move: Move): boolean {
+  const car = state.cars.find(c => c.id === move.carId);
+  if (!car || move.steps < 1) {
+    return false;
+  }
+
+  // orientation check
+  if (
+    (car.orientation === 'horizontal' && (move.direction === 'up' || move.direction === 'down')) ||
+    (car.orientation === 'vertical' && (move.direction === 'left' || move.direction === 'right'))
+  ) {
+    return false;
+  }
+
+  const grid = getOccupiedGrid(state);
+  const mainCar = state.cars.find(c => c.isMain);
+  const exitX = state.boardSize - 1;
+  const exitY = mainCar?.y ?? -1;
+
+  for (let step = 1; step <= move.steps; step++) {
+    let checkX = car.x;
+    let checkY = car.y;
+
+    if (car.orientation === 'horizontal') {
+      if (move.direction === 'right') {
+        checkX = car.x + car.length - 1 + step;
+        checkY = car.y;
+      } else {
+        checkX = car.x - step;
+        checkY = car.y;
+      }
+    } else {
+      if (move.direction === 'down') {
+        checkX = car.x;
+        checkY = car.y + car.length - 1 + step;
+      } else {
+        checkX = car.x;
+        checkY = car.y - step;
+      }
+    }
+
+    if (
+      checkX < 0 ||
+      checkY < 0 ||
+      checkX >= state.boardSize ||
+      checkY >= state.boardSize
+    ) {
+      return false;
+    }
+
+    if (!car.isMain && checkX === exitX && checkY === exitY) {
+      return false;
+    }
+
+    const occupant = grid[checkY][checkX];
+    if (occupant && occupant !== car.id) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+export function applyMove(state: GameState, move: Move): GameState {
+  if (!isMoveLegal(state, move)) {
+    return state;
+  }
+  const cars = state.cars.map(c => {
+    if (c.id !== move.carId) {
+      return { ...c };
+    }
+    let { x, y } = c;
+    switch (move.direction) {
+      case 'left':
+        x -= move.steps;
+        break;
+      case 'right':
+        x += move.steps;
+        break;
+      case 'up':
+        y -= move.steps;
+        break;
+      case 'down':
+        y += move.steps;
+        break;
+    }
+    return { ...c, x, y };
+  });
+
+  const newState: GameState = {
+    boardSize: state.boardSize,
+    cars,
+    moveCount: state.moveCount + 1,
+    isCleared: false,
+    history: [...state.history, move]
+  };
+
+  newState.isCleared = isCleared(newState);
+  return newState;
+}
+
+export function isCleared(state: GameState): boolean {
+  const mainCar = state.cars.find(c => c.isMain);
+  if (!mainCar) {
+    return false;
+  }
+  const endX = mainCar.x + mainCar.length - 1;
+  return endX === state.boardSize - 1;
+}


### PR DESCRIPTION
## Summary
- implement `game.service` with basic move logic and victory detection
- add Jasmine tests for collisions, boundary checks and win condition

## Testing
- `npm test` *(fails: No binary for Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_6857697513808324a04ef3cb89bf6f70