### PR TITLE
Set test watch mode off

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,16 @@ This will compile your project and store the build artifacts in the `dist/` dire
 
 ## Running unit tests
 
-To execute unit tests with the [Karma](https://karma-runner.github.io) test runner, use the following command:
+To execute unit tests once, run:
 
 ```bash
-ng test
+npm test
+```
+
+For watch mode, use:
+
+```bash
+npm run test:watch
 ```
 
 ## Running end-to-end tests

--- a/angular.json
+++ b/angular.json
@@ -74,6 +74,7 @@
           "options": {
             "karmaConfig": "karma.conf.js",
             "tsConfig": "tsconfig.spec.json",
+            "watch": false,
             "inlineStyleLanguage": "scss",
             "assets": [
               {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "start": "ng serve",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
-    "test": "ng test"
+    "test": "ng test --watch=false",
+    "test:watch": "ng test --watch=true"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
## Summary
- run `ng test` with `--watch=false`
- configure Angular test options to disable watch mode
- add `npm run test:watch` script for running tests in watch mode
- document test scripts in README

## Testing
- `npm test`
- `npm run test:watch`


------
https://chatgpt.com/codex/tasks/task_e_6857906d444883248fe243e2b3195191