### PR TITLE
Rename puzzle types to level

### DIFF
--- a/src/app/game/types/level.ts
+++ b/src/app/game/types/level.ts
@@ -1,7 +1,7 @@
 import { Car } from './car';
 import { Point } from './point';
 
-export interface Puzzle {
+export interface Level {
   /** 盤面の一辺の長さ。6 なら 6x6 グリッド。 */
   boardSize: number;
 

--- a/src/app/game/types/state.ts
+++ b/src/app/game/types/state.ts
@@ -1,10 +1,10 @@
 import { Action } from './action';
 import { Frame } from './frame';
-import { Puzzle } from './puzzle';
+import { Level } from './level';
 
 export interface State {
-  /** パズルの設定。 */
-  puzzle: Puzzle;
+  /** レベルの設定。 */
+  level: Level;
   /** 全てのフレーム。 */
   frames: Frame[];
   /** これまでの操作履歴。 */


### PR DESCRIPTION
## Summary
- rename `Puzzle` interface to `Level`
- update state type to use `Level`

## Testing
- `npm test` *(fails: `npm` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857a55d7f94832495afbbc576e1b664