### PR TITLE
Add Storybook integration

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,0 +1,13 @@
+// Storybook メイン設定ファイル
+import type { StorybookConfig } from '@storybook/angular';
+
+const config: StorybookConfig = {
+  stories: ['../src/**/*.stories.@(ts|js)'],
+  addons: ['@storybook/addon-essentials'],
+  framework: {
+    name: '@storybook/angular',
+    options: {},
+  },
+  docs: { autodocs: 'tag' },
+};
+export default config;

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,0 +1,11 @@
+// Storybook プレビュー設定
+import type { Preview } from '@storybook/angular';
+
+const preview: Preview = {
+  parameters: {
+    actions: { argTypesRegex: '^on[A-Z].*' },
+    controls: { expanded: true },
+  },
+};
+
+export default preview;

--- a/.storybook/tsconfig.json
+++ b/.storybook/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig.app.json",
+  "exclude": ["../src/**/*.spec.ts", "../src/**/*.e2e.ts"]
+}

--- a/README.md
+++ b/README.md
@@ -60,6 +60,16 @@ ng e2e
 
 Angular CLI does not come with an end-to-end testing framework by default. You can choose one that suits your needs.
 
+## Storybook
+
+To launch Storybook, run:
+
+```bash
+npm run storybook
+```
+
+This command starts Storybook on `http://localhost:6006/`.
+
 ## Additional Resources
 
 For more information on using the Angular CLI, including detailed command references, visit the [Angular CLI Overview and Command Reference](https://angular.dev/tools/cli) page.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "watch": "ng build --watch --configuration development",
     "test": "ng test --watch=false",
     "test:watch": "ng test --watch=true",
-    "format": "prettier --write '**/*.{ts,html,scss,js,json,md}'"
+    "format": "prettier --write '**/*.{ts,html,scss,js,json,md}'",
+    "storybook": "storybook dev -p 6006",
+    "build-storybook": "storybook build"
   },
   "private": true,
   "dependencies": {
@@ -38,6 +40,8 @@
     "karma-jasmine-html-reporter": "~2.1.0",
     "prettier": "3.5.3",
     "puppeteer": "^22.7.0",
-    "typescript": "~5.8.2"
+    "typescript": "~5.8.2",
+    "@storybook/angular": "^8.0.0",
+    "@storybook/addon-essentials": "^8.0.0"
   }
 }

--- a/src/app/app.stories.ts
+++ b/src/app/app.stories.ts
@@ -1,0 +1,11 @@
+// アプリケーションのルートコンポーネント用ストーリー
+import type { Meta, StoryObj } from '@storybook/angular';
+import { App } from './app';
+
+const meta: Meta<App> = {
+  title: 'App',
+  component: App,
+};
+export default meta;
+
+export const Default: StoryObj<App> = {};

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -6,5 +6,6 @@
     "outDir": "./out-tsc/spec",
     "types": ["jasmine"]
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.stories.ts"]
 }

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -7,5 +7,5 @@
     "types": ["jasmine"]
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["src/**/*.stories.ts"]
+  "exclude": ["src/**/*.stories.ts", "src/**/*.stories.js"]
 }


### PR DESCRIPTION
## Summary
- add Storybook config
- add a basic story for `App`
- document Storybook usage in the README
- exclude stories from test build

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6857a9420cc08324a138822e681d0e85